### PR TITLE
Add clang to fix the docker build on x86

### DIFF
--- a/Dockerfile_x86
+++ b/Dockerfile_x86
@@ -11,6 +11,7 @@ ENV LIBGL_ALWAYS_INDIRECT=1
 
 # Update package list and install basic utilities
 RUN apt-get update && apt-get install -y \
+    clang \
     curl \
     git \
     wget \


### PR DESCRIPTION
Fix for https://github.com/openai/SWELancer-Benchmark/issues/2