### PR TITLE
Fix: Docs typos and default timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ done
 To use your own virtualenv, without uv, run:
 
 ```bash
-python -m venv venv
+python -m venv .venv
 source venv/bin/activate
 pip install -r requirements.txt
 for proj in nanoeval alcatraz nanoeval_alcatraz; do
@@ -50,7 +50,7 @@ docker buildx build \
   -f Dockerfile_x86 \
   --platform linux/amd64 \
   --ssh default=$SSH_AUTH_SOCK \
-  -t swelancer_x86 \
+  -t swelancer \
   .
 ```
 
@@ -75,7 +75,7 @@ Create a new file named `.env` and copy the contents from `sample.env`.
 You are now ready to run the eval with:
 
 ```bash
-python run_swelancer.py
+uv run python run_swelancer.py
 ```
 
 You should immediately see logging output as the container gets set up and the tasks are loaded, which may take several minutes. You can adjust the model, concurrency, recording, and other parameters in `run_swelancer.py`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To use your own virtualenv, without uv, run:
 
 ```bash
 python -m venv .venv
-source venv/bin/activate
+source .venv/bin/activate
 pip install -r requirements.txt
 for proj in nanoeval alcatraz nanoeval_alcatraz; do
   pip install -e project/"$proj"

--- a/project/alcatraz/alcatraz/clusters/local.py
+++ b/project/alcatraz/alcatraz/clusters/local.py
@@ -70,6 +70,8 @@ _WAIT_FOR_TIMEOUT_INTERRUPT = 10
 # Do not use dynamic ports here (32_768-65_535) because they are not guaranteed to be open on Linux.
 _FREE_PORTS: set[int] = set(range(*map(int, os.getenv("FREE_PORTS", "10000-32767").split("-"))))
 
+ALCATRAZ_TIMEOUT = int(os.getenv("ALCATRAZ_TIMEOUT", 60))
+
 VS_CODE_PORT = 8000
 
 
@@ -915,7 +917,7 @@ class BaseAlcatrazCluster(ABC):
 
         self._exit_stack.callback(asyncio.create_task(self._jupyter_start_kernel()).cancel)
 
-        async with asyncio.timeout(60):
+        async with asyncio.timeout(ALCATRAZ_TIMEOUT):
             # Poll in runtime_dir until we find the connection file path.
             while True:
                 connection_files = await self._jupyter_list_connection_files()
@@ -1130,7 +1132,7 @@ class BaseAlcatrazCluster(ABC):
 
         self._exit_stack.push_async_callback(cleanup)
 
-        await self._kernel.wait_for_ready(timeout=60.0)
+        await self._kernel.wait_for_ready(timeout=ALCATRAZ_TIMEOUT)
         assert await self.kernel_is_alive()
         logger.info("Kernel is alive!")
 

--- a/project/nanoeval_alcatraz/nanoeval_alcatraz/alcatraz_computer_interface.py
+++ b/project/nanoeval_alcatraz/nanoeval_alcatraz/alcatraz_computer_interface.py
@@ -1,3 +1,4 @@
+import os
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator, Literal, cast
@@ -20,7 +21,7 @@ from nanoeval.solvers.computer_tasks.code_execution_interface import (
 from nanoeval_alcatraz.task_to_alcatraz_config import task_to_alcatraz_config
 
 logger = structlog.stdlib.get_logger(component=__name__)
-
+ALCATRAZ_TIMEOUT = int(os.getenv("ALCATRAZ_TIMEOUT", 120))
 
 class Python3ExceptionDict(BaseModel):
     """A pydantic model for serializing a Python 3.x exception.
@@ -65,7 +66,7 @@ class BaseAlcatrazComputerInterface(JupyterComputerInterface, ABC):
         await self.cluster._stop()
 
     @override
-    async def execute(self, code: str, timeout: int = 120) -> JupyterExecutionResult:
+    async def execute(self, code: str, timeout: int = ALCATRAZ_TIMEOUT) -> JupyterExecutionResult:
         await self._start_cluster_once()
 
         messages = await self.cluster.send_kernel_command(code, timeout=timeout)

--- a/sample.env
+++ b/sample.env
@@ -1,3 +1,4 @@
 USE_WEB_PROXY=false
 EXPENSIFY_URL=https://www.expensify.com/
 NEW_EXPENSIFY_URL=https://new.expensify.com/
+ALCATRAZ_TIMEOUT=360


### PR DESCRIPTION
Hi!

Tried reproducing the setup instructions with the new venv and encountered the following errors, which this PR addresses:

1. Default timeouts for tasks in alcatraz were too low, containers would not make it past the NPM install

2. typo in venv in readme lead to creation of new venv instead of .venv

3. Building the x86 container would not run the default, since the code expects the container name to be `swelancer` not `swelancer_x86` and would fail on container pull

4. using `python` instead of `uv run python` would lead to the dotenv module not being found, despite it being in `pip list -v` Using uv solved it for both envs on linux.


```
Evaluated 2 tasks with SWELancer component=nanoeval.evaluation
2025-02-19T13:48:37.294892Z [info     ] Evalboard Summary: unknown, add in pr? component=nanoeval.evaluation
SWELancer (r_id=250219132942TSUICGEH, m=nanoeval): 100%|███████████████████████████████████████████████████████████████████| 2/2 [18:54<00:00, 567.44s/it, corr=2, errs=0, fail=0]
{'accuracy': np.float64(1.0), 'aggregations': {'num_tasks': 2, 'num_attempts': 2, 'num_correct': 2, 'num_incorrect': 0, 'num_system_error': 0, 'error_breakdown': {}}, 'metrics_including_errors': {'accuracy': np.float64(1.0), 'aggregations': {'num_tasks': 2, 'num_attempts': 2, 'num_correct': 2, 'num_incorrect': 0, 'num_system_error': 0, 'error_breakdown': {}}}, 'missing_tasks': [], 'is_valid': True, 'length_stats': {'frac_correct': 1.0, 'frac_max_time': 0.0, 'frac_max_steps': 0.0, 'frac_max_tokens': 0.0, 'frac_model_ended': 0.0}}
```