### PR TITLE
Fix mitmdump random fault while container startup

### DIFF
--- a/runtime_scripts/setup_mitmproxy.yml
+++ b/runtime_scripts/setup_mitmproxy.yml
@@ -8,20 +8,13 @@
         state: directory
         mode: '0755'
   
-    - name: Start mitmdump in the background
+    - name: Start mitmdump to generate certificates
       shell: |
-        nohup mitmdump --mode transparent --showhost 2>&1 & echo $! > /tmp/mitmdump.pid
-      async: 1
-      poll: 0
+        mitmdump --mode transparent --showhost &
+        MITMDUMP_PID=$!
+        sleep 10
+        kill -9 $MITMDUMP_PID
 
-    - name: Wait for mitmdump to start
-      pause:
-        seconds: 10
-
-    - name: Stop mitmdump
-      shell: "kill `cat /tmp/mitmdump.pid`"
-      ignore_errors: yes
-    
     - name: Ensure mitmproxy-ca-cert.pem is present
       assert:
         that:


### PR DESCRIPTION
If mitmdump started slow (> T+1s), the process of the async shell task
```bash
nohup mitmdump --mode transparent --showhost 2>&1 & echo $! > /tmp/mitmdump.pid
```
exits too soon (whenever the echo finished).

One second later, the ansible-playbook, which polls every 1s to check whether stdout/process is active, will find the shell process has exited. Subsequently, the stdout/stderr pipes will be closed from the ansible-playbook side, leaving the stdout/stderr fds of the daemonized mitmdump dangling.

When mitmdump will finally print the one-line log message "[HH:mm:ss.xxxx] Transparent Proxy listening at *:8080." to the console, a syscall "write" fails with EPIPE, triggers SIGPIPE and crashes the main program, stops the container, prevents the benchmark from running.

This patch fixes the issue by doing the start-wait-kill trick in one synchronised ansible task.