### PR TITLE
added check for canary field before deletion

### DIFF
--- a/swelancer.py
+++ b/swelancer.py
@@ -321,7 +321,8 @@ class SWELancerEval(PythonCodingEval):
             SWEFL_ENV["ISSUE_ID"] = task["question_id"]
 
             del task['price_limit']
-            del task['canary']
+            if 'canary' in task:
+                del task['canary']
             swelancer_tasks.append(SWELancerTask(**task, attempt_id=str(i), environment=SWEFL_ENV, grade_every_step=False, docker_image=docker_image, instance=SwelancerInstance(repo="expensify"))) # type: ignore
             i += 1
         return swelancer_tasks


### PR DESCRIPTION
#72 
The `swelancer_tasks_lite.csv` does not seem to have a `canary` column. This gives an error in `swelancer.py`'s `get_tasks` method when using the lite dataset.
Line 324 `del task['canary']`.

The PR:
- adds a check for the `canary` field before its deletion